### PR TITLE
Updated URL for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Canadian Incident Action Plan Producer 
 
-![Canadian Incident Action Plan Producer](https://github.com/ciffc-devops/ciapp/blob/main/Wildfire%20ICS%20Assist/Resources/CIAPP-LOGO-v3.png)
+![Canadian Incident Action Plan Producer](https://github.com/ciffc-devops/ciapp/blob/main/Wildfire%20ICS%20Assist/Resources/CIAPP-LOGO-v3.png?raw=true)
 
 This program was create by CIFFC (Canadian Interagency Forest Fire Centre) to assist incident command teams in creating the incident action plan used during wildfire events.
 


### PR DESCRIPTION
Previous URL was pointing at an old branch, updated to point at main. Fixed my own mistake of removing `raw=True` to ensure proper rendering.